### PR TITLE
Lock to Debian 10 as required by msodbcsql17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8 as base-python
+FROM python:3.8-buster as base-python
 
 RUN apt-get clean \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \


### PR DESCRIPTION
The `python:3.8` Docker image switched from Debian 10 (buster) to Debian 11 (bullseye). However, the `msodbcsql17` package does not yet support Debian 11:
https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver15#debian17

Building the Docker image will result in an [error](https://stackoverflow.com/questions/68846245/failing-installation-of-msodbcsql17) about unmet dependencies:

```
#7 23.56 The following packages have unmet dependencies:
#7 23.80  libodbc1 : PreDepends: multiarch-support but it is not installable
#7 23.80  odbcinst1debian2 : PreDepends: multiarch-support but it is not installable
#7 23.83 E: Unable to correct problems, you have held broken packages.
```

This change locks the distribution to Debian 10. Keeping a consistent distribution can possibly save some other issues down the line as well.